### PR TITLE
Fix some deprecation warnings for Rspec and Ruby 2.7

### DIFF
--- a/lib/troupe/contract.rb
+++ b/lib/troupe/contract.rb
@@ -5,8 +5,12 @@ module Troupe
     def self.included(base)
       base.class_eval do
         extend ClassMethods
+        include InstanceMethods
       end
 
+    end
+
+    module InstanceMethods
       private
 
       def violation_table

--- a/spec/troupe/contract_spec.rb
+++ b/spec/troupe/contract_spec.rb
@@ -15,7 +15,7 @@ module Troupe
           build_contracted do
             property :property, presence: :foo
           end
-        }.to raise_error
+        }.to raise_error(RuntimeError, "Invalid value 'foo' for option presence")
       end
 
       it "does not raise an error if the context includes an unexpected property" do


### PR DESCRIPTION
Fixes #6 

This switches to using a module to define private methods within the `included` block

I also fixed a Spec warning around `raise_error` without params